### PR TITLE
Update RightClickHorseEvent.kt

### DIFF
--- a/src/main/kotlin/com/deviseworks/inspecthorse/events/RightClickHorseEvent.kt
+++ b/src/main/kotlin/com/deviseworks/inspecthorse/events/RightClickHorseEvent.kt
@@ -21,8 +21,11 @@ class RightClickHorseEvent: Listener {
                 targetEntity.type == EntityType.ZOMBIE_HORSE){
             val horse = targetEntity as Horse
             val name = horse.customName
-            val speed =horse.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED)?.value?.times(100)
-            val jump = horse.jumpStrength.times(100)
+            val speed =horse.getAttribute(Attribute.GENERIC_MOVEMENT_SPEED)?.value?
+            val jump = horse.jumpStrength
+            
+            speed = speed*4.31
+            jump = 3.0509*jump*jump+2.7941*jump-0.5525
 
             e.player.sendMessage("${ChatColor.AQUA}${ChatColor.STRIKETHROUGH} |                                     | ")
             if(!name.isNullOrEmpty()) e.player.sendMessage("名前: $name")


### PR DESCRIPTION
表示する数値をエンティティが持つ属性ではなくマイクラのブロックを基準とした数値にするように式を追加した